### PR TITLE
fix: Make other key work when no ssh keys found

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -596,7 +596,7 @@ export default function App() {
         if (keys && keys.length > 0) {
           setSelectedKey(keys[0].path)
         } else {
-          setSelectedKey('__other__')
+          setSelectedKey('')
         }
         setSSHAgentAvailable(!!agentAvail)
 
@@ -635,7 +635,7 @@ export default function App() {
         }
       } catch (err) {
         debugLog('Could not load initial data:', err)
-        setSelectedKey('__other__')
+        setSelectedKey('')
       }
     }
     loadInitialData()
@@ -704,6 +704,8 @@ export default function App() {
         setSelectedKey(path)
         const fileName = path.split('/').pop() || path
         setCustomKeyName(fileName)
+      } else if (!selectedKey) {
+        setCustomKeyName('')
       }
     } else {
       setSelectedKey(value)
@@ -868,6 +870,8 @@ export default function App() {
     setDeviceName('')
     if (availableKeys.length > 0) {
       setSelectedKey(availableKeys[0].path)
+    } else {
+      setSelectedKey('')
     }
   }
 
@@ -2281,7 +2285,7 @@ export default function App() {
                       ) : editingDevice ? (
                         <Button
                           onClick={handleSaveEditedDevice}
-                          disabled={!deviceName.trim() || (authType === 'agent' ? false : authType === 'password' ? !password : !selectedKey || selectedKey === '__other__')}
+                          disabled={!deviceName.trim() || (authType === 'agent' ? false : authType === 'password' ? !password : !selectedKey)}
                         >
                           Save
                         </Button>
@@ -2290,13 +2294,13 @@ export default function App() {
                           <Button
                             variant="outline"
                             onClick={() => handleConnect(false)}
-                            disabled={authType === 'agent' ? false : authType === 'password' ? !password : !selectedKey || selectedKey === '__other__'}
+                            disabled={authType === 'agent' ? false : authType === 'password' ? !password : !selectedKey}
                           >
                             Connect
                           </Button>
                           <Button
                             onClick={() => handleConnect(true)}
-                            disabled={authType === 'agent' ? false : authType === 'password' ? !password : !selectedKey || selectedKey === '__other__'}
+                            disabled={authType === 'agent' ? false : authType === 'password' ? !password : !selectedKey}
                           >
                             Save and Connect
                           </Button>


### PR DESCRIPTION
Firstly! Super super cool project.
Thank you for using wails, I finally have an excuse to dive into html frontend + golang backend.


# Issue
- Installed reManager via brew.
- I have no ssh keys with the prefix "id_".
- UI already has Other selected.
- Unable to trigger the "Other popup dialog"
- When I created a throw away id_* ssh key, Other popup dialog worked.

# Video of the fix
https://github.com/user-attachments/assets/40fb2ed7-2051-4249-a622-155af5f2f134

# Notes
- I installed latest wails so it wanted to bump go.mod
```
github.com/wailsapp/wails/v2 v2.12.0
```
- I have "format on save" enabled, and it reformatted the App.tsx file a lot, codex and I, couldn't find any formatters / linters. Is this user error or is it missing?

